### PR TITLE
BUILDER-86: Added Cloud Connector mock event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The generated events are selected from one of the following events categories:
 * ACS_PUBLIC_EVENT
 * ACTIVITI_RAW_EVENT
 * ACTIVITI_PUBLIC_EVENT
+* CLOUD_CONNECTOR_EVENT
 
 The default events category is **_ACS_PUBLIC_EVENT_**.
 To override the default you can use System property:
@@ -57,7 +58,7 @@ To start the application with Kafka:
 Executing any of the above commands will start the application, connect to the given broker and send **10** messages with a pause time of **1** second between each message.
 The messages are sent to the defined topic. See _**camelRoute.destinationName**_ in the application.yml file.
 
-#### Sending events via REST API
+### Sending events via REST API
 
 If you want to send events upon request rather than at the bootstrap time, then set the `startSendAtStartup` property to *false*:
 
@@ -77,6 +78,60 @@ then do an HTTP POST to the following URL:
         "pauseTimeInMillis" : 50
     }
 ```
+
+### Sending custom Cloud Connector events via REST API and RabbitMQ
+
+The Cloud Connector event is a special case where you can **_override_** the `inBoundVariables` and/or `outBoundVariables` attributes.
+
+The default Cloud Connector event looks like:
+
+```
+{
+    "appName": "default-app",
+    "appVersion": "",
+    "serviceName": "rb-my-app",
+    "serviceFullName": "rb-my-app",
+    "serviceType": "runtime-bundle",
+    "serviceVersion": "",
+    "integrationContext": {
+        "id": "1c7b99de-fa50-11e8-9b6d-8efb5254abd4",
+        "outBoundVariables": {},
+        "processInstanceId": "1c7b72c8-fa50-11e8-9b6d-8efb5254abd4",
+        "processDefinitionId": "ConnectorProcess:1:41f6f25f-fa0a-11e8-9b6d-8efb5254abd4",
+        "activityElementId": "sid-CDFE7219-4627-43E9-8CA8-866CC38EBA94",
+        "connectorType": "Example Connector",
+        "inBoundVariables": {
+            "firstName": "Paulo",
+            "lastName": "Silva",
+            "age": 25
+        }
+    }
+}
+```
+
+To override the default event, first run the application with the following settings:
+
+    mvn spring-boot:run -Dspring.profiles.active=rabbitMQ -Dgenerator.startSendAtStartup=false -Dgenerator.eventCategory=CLOUD_CONNECTOR_EVENT -Dmessaging.to.rabbitmq.camelRoute.destinationName="Example Connector"
+
+then do an HTTP POST to the following URL:
+
+    http://<host>:<port>/alfresco/mock/connector-event
+
+Request payload example:
+
+```
+{
+    "inBoundVariables": {
+      "nodeId": "bd285b4f-9ee4-11e8-9079-0242ac118745",
+      "properties": {
+        "cm:title": "Node Title",
+        "cm:description": "Node Description"
+      }
+    }
+}
+```
+
+**Note:** `inBoundVariables` and `outBoundVariables` are of type `Map<String, Object>` so you can add whatever you require withing the JSON body.
 
 # Scheduled Run
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Request payload example:
 }
 ```
 
-**Note:** `inBoundVariables` and `outBoundVariables` are of type `Map<String, Object>` so you can add whatever you require withing the JSON body.
+**Note:** `inBoundVariables` and `outBoundVariables` are of type `Map<String, Object>` so you can add whatever you require within the JSON body.
 
 # Scheduled Run
 

--- a/src/main/java/org/alfresco/mockeventgenerator/EventSender.java
+++ b/src/main/java/org/alfresco/mockeventgenerator/EventSender.java
@@ -57,14 +57,17 @@ public class EventSender
     {
         for (int i = 0; i < numOfEvents; i++)
         {
-            try
+            sendEvent(eventTypeCategory.getRandomEvent());
+            if (pauseTimeMillis > 0)
             {
-                sendEvent(eventTypeCategory.getRandomEvent());
-                Thread.sleep(pauseTimeMillis);
-            }
-            catch (InterruptedException e)
-            {
-                LOGGER.info(e.getMessage());
+                try
+                {
+                    Thread.sleep(pauseTimeMillis);
+                }
+                catch (InterruptedException e)
+                {
+                    LOGGER.info(e.getMessage());
+                }
             }
         }
     }

--- a/src/main/java/org/alfresco/mockeventgenerator/config/EventConfig.java
+++ b/src/main/java/org/alfresco/mockeventgenerator/config/EventConfig.java
@@ -21,6 +21,7 @@ import org.alfresco.event.databind.EventObjectMapperFactory;
 import org.alfresco.event.model.EventV1;
 import org.alfresco.event.model.ResourceV1;
 import org.alfresco.mockeventgenerator.EventMaker;
+import org.alfresco.mockeventgenerator.model.CloudConnectorIntegrationRequest;
 import org.alfresco.sync.events.types.RepositoryEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -76,6 +77,10 @@ public class EventConfig
             {
                 return EventObjectMapperFactory.createInstance();
             }
+            case CLOUD_CONNECTOR_EVENT:
+            {
+                return EventObjectMapperFactory.createInstance();
+            }
             default:
             {
                 throw new RuntimeException("No mapper is defined for the: " + eventTypeCategory);
@@ -127,6 +132,14 @@ public class EventConfig
             public List<EventV1<? extends ResourceV1>> getRandomEvent()
             {
                 return EventMaker.getRandomPublicActivitiEvent();
+            }
+        },
+        CLOUD_CONNECTOR_EVENT()
+        {
+            @Override
+            public CloudConnectorIntegrationRequest getRandomEvent()
+            {
+                return EventMaker.getRandomCloudConnectorEvent();
             }
         };
 

--- a/src/main/java/org/alfresco/mockeventgenerator/model/CloudConnectorIntegrationRequest.java
+++ b/src/main/java/org/alfresco/mockeventgenerator/model/CloudConnectorIntegrationRequest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 Alfresco Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.mockeventgenerator.model;
+
+import java.util.Map;
+
+/**
+ * @author Jamal Kaabi-Mofrad
+ */
+public class CloudConnectorIntegrationRequest
+{
+    private String appName;
+    private String appVersion;
+    private String serviceName;
+    private String serviceFullName;
+    private String serviceType;
+    private String serviceVersion;
+    private IntegrationContext integrationContext;
+
+    public String getAppName()
+    {
+        return appName;
+    }
+
+    public void setAppName(String appName)
+    {
+        this.appName = appName;
+    }
+
+    public String getAppVersion()
+    {
+        return appVersion;
+    }
+
+    public void setAppVersion(String appVersion)
+    {
+        this.appVersion = appVersion;
+    }
+
+    public String getServiceName()
+    {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName)
+    {
+        this.serviceName = serviceName;
+    }
+
+    public String getServiceFullName()
+    {
+        return serviceFullName;
+    }
+
+    public void setServiceFullName(String serviceFullName)
+    {
+        this.serviceFullName = serviceFullName;
+    }
+
+    public String getServiceType()
+    {
+        return serviceType;
+    }
+
+    public void setServiceType(String serviceType)
+    {
+        this.serviceType = serviceType;
+    }
+
+    public String getServiceVersion()
+    {
+        return serviceVersion;
+    }
+
+    public void setServiceVersion(String serviceVersion)
+    {
+        this.serviceVersion = serviceVersion;
+    }
+
+    public IntegrationContext getIntegrationContext()
+    {
+        return integrationContext;
+    }
+
+    public void setIntegrationContext(IntegrationContext integrationContext)
+    {
+        this.integrationContext = integrationContext;
+    }
+
+    public static class IntegrationContext
+    {
+        private String id;
+        private String processInstanceId;
+        private String processDefinitionId;
+        private String connectorType;
+        private String activityElementId;
+        private Map<String, Object> inBoundVariables;
+        private Map<String, Object> outBoundVariables;
+
+        public String getId()
+        {
+            return id;
+        }
+
+        public void setId(String id)
+        {
+            this.id = id;
+        }
+
+        public String getProcessInstanceId()
+        {
+            return processInstanceId;
+        }
+
+        public void setProcessInstanceId(String processInstanceId)
+        {
+            this.processInstanceId = processInstanceId;
+        }
+
+        public String getProcessDefinitionId()
+        {
+            return processDefinitionId;
+        }
+
+        public void setProcessDefinitionId(String processDefinitionId)
+        {
+            this.processDefinitionId = processDefinitionId;
+        }
+
+        public String getConnectorType()
+        {
+            return connectorType;
+        }
+
+        public void setConnectorType(String connectorType)
+        {
+            this.connectorType = connectorType;
+        }
+
+        public String getActivityElementId()
+        {
+            return activityElementId;
+        }
+
+        public void setActivityElementId(String activityElementId)
+        {
+            this.activityElementId = activityElementId;
+        }
+
+        public Map<String, Object> getInBoundVariables()
+        {
+            return inBoundVariables;
+        }
+
+        public void setInBoundVariables(Map<String, Object> inBoundVariables)
+        {
+            this.inBoundVariables = inBoundVariables;
+        }
+
+        public Map<String, Object> getOutBoundVariables()
+        {
+            return outBoundVariables;
+        }
+
+        public void setOutBoundVariables(Map<String, Object> outBoundVariables)
+        {
+            this.outBoundVariables = outBoundVariables;
+        }
+    }
+}

--- a/src/main/java/org/alfresco/mockeventgenerator/util/UserInfo.java
+++ b/src/main/java/org/alfresco/mockeventgenerator/util/UserInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Alfresco Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.alfresco.mockeventgenerator.util;
+
+/**
+ * @author Jamal Kaabi-Mofrad
+ */
+public class UserInfo
+{
+    private String firstName;
+    private String lastName;
+    private int age;
+    private String userName;
+
+    public UserInfo()
+    {
+    }
+
+    public UserInfo(String firstName, String lastName, int age, String userName)
+    {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.age = age;
+        this.userName = userName;
+    }
+
+    public String getFirstName()
+    {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName)
+    {
+        this.firstName = firstName;
+    }
+
+    public String getLastName()
+    {
+        return lastName;
+    }
+
+    public void setLastName(String lastName)
+    {
+        this.lastName = lastName;
+    }
+
+    public int getAge()
+    {
+        return age;
+    }
+
+    public void setAge(int age)
+    {
+        this.age = age;
+    }
+
+    public String getUserName()
+    {
+        return userName;
+    }
+
+    public void setUserName(String userName)
+    {
+        this.userName = userName;
+    }
+
+    @Override
+    public String toString()
+    {
+        final StringBuilder sb = new StringBuilder(100);
+        sb.append("UserInfo [firstName=").append(firstName)
+                    .append(", lastName=").append(lastName)
+                    .append(", age=").append(age)
+                    .append(", userName=").append(userName)
+                    .append(']');
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
         active: activeMQ
 
 generator:
-    # Available category: ACS_RAW_EVENT|ACS_PUBLIC_EVENT|ACTIVITI_RAW_EVENT|ACTIVITI_PUBLIC_EVENT
+    # Available category: ACS_RAW_EVENT|ACS_PUBLIC_EVENT|ACTIVITI_RAW_EVENT|ACTIVITI_PUBLIC_EVENT|CLOUD_CONNECTOR_EVENT
     eventCategory: ACS_PUBLIC_EVENT
     startSendAtStartup: true
     # This property will be ignored if 'startSendAtStartup' is set to false

--- a/src/test/java/org/alfresco/mockeventgenerator/AbstractCamelTest.java
+++ b/src/test/java/org/alfresco/mockeventgenerator/AbstractCamelTest.java
@@ -108,6 +108,9 @@ public abstract class AbstractCamelTest
     @Test
     public void testSendAndReceiveMockAcsRawEvent() throws Exception
     {
+        // Override camelMessageProducer mapper
+        camelMessageProducer.setObjectMapper(RAW_OBJECT_MAPPER);
+
         // Generate random events
         RepositoryEvent event1 = EventMaker.getRandomRawAcsEvent();
         RepositoryEvent event2 = EventMaker.getRandomRawAcsEvent();
@@ -131,9 +134,6 @@ public abstract class AbstractCamelTest
     @Test
     public void testSendAndReceiveMockAcsPublicEvent() throws Exception
     {
-        // Override camelMessageProducer mapper
-        camelMessageProducer.setObjectMapper(PUBLIC_OBJECT_MAPPER);
-
         // Generate random events
         EventV1<? extends ResourceV1> event1 = EventMaker.getRandomPublicAcsEvent();
         EventV1<? extends ResourceV1> event2 = EventMaker.getRandomPublicAcsEvent();
@@ -179,9 +179,6 @@ public abstract class AbstractCamelTest
     @Test
     public void testSendAndReceiveMockActivitiPublicEvent() throws Exception
     {
-        // Override camelMessageProducer mapper
-        camelMessageProducer.setObjectMapper(PUBLIC_OBJECT_MAPPER);
-
         // Generate random events
         List<EventV1<? extends ResourceV1>> events1 = PublicActivitiEventInstance.PROCESS_CREATED.getEvents();
         List<EventV1<? extends ResourceV1>> events2 = PublicActivitiEventInstance.TASK_ASSIGNED.getEvents();
@@ -212,9 +209,6 @@ public abstract class AbstractCamelTest
     @Test
     public void testSendAndReceiveMockConnectorEvent() throws Exception
     {
-        // Override camelMessageProducer mapper
-        camelMessageProducer.setObjectMapper(PUBLIC_OBJECT_MAPPER);
-
         // Generate random events
         CloudConnectorIntegrationRequest event1 = EventMaker.getRandomCloudConnectorEvent();
         CloudConnectorIntegrationRequest event2 = EventMaker.getRandomCloudConnectorEvent();
@@ -269,7 +263,7 @@ public abstract class AbstractCamelTest
 
         String receivedEvent = getBody(mockEndpoint, 0);
         assertNotNull(receivedEvent);
-        assertTrue(receivedEvent.contains(defaultObjectMapper.writeValueAsString(inBoundVariables)));
+        assertTrue(receivedEvent.contains(PUBLIC_OBJECT_MAPPER.writeValueAsString(inBoundVariables)));
 
         // Checks that the received message count is equal to the number of messages sent
         mockEndpoint.assertIsSatisfied();
@@ -298,8 +292,8 @@ public abstract class AbstractCamelTest
 
         String receivedEvent = getBody(mockEndpoint, 0);
         assertNotNull(receivedEvent);
-        assertTrue(receivedEvent.contains(defaultObjectMapper.writeValueAsString(inBoundVariables)));
-        assertTrue(receivedEvent.contains(defaultObjectMapper.writeValueAsString(outBoundVariables)));
+        assertTrue(receivedEvent.contains(PUBLIC_OBJECT_MAPPER.writeValueAsString(inBoundVariables)));
+        assertTrue(receivedEvent.contains(PUBLIC_OBJECT_MAPPER.writeValueAsString(outBoundVariables)));
 
         // Checks that the received message count is equal to the number of messages sent
         mockEndpoint.assertIsSatisfied();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 generator:
     # Available category: ACS_RAW_EVENT|ACS_PUBLIC_EVENT|ACTIVITI_RAW_EVENT|ACTIVITI_PUBLIC_EVENT|CLOUD_CONNECTOR_EVENT
-    eventCategory: ACS_RAW_EVENT
+    eventCategory: ACS_PUBLIC_EVENT
     startSendAtStartup: false
 
 messaging:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,7 +2,7 @@ server:
     port: 9090
 
 generator:
-    # Available category: ACS_RAW_EVENT|ACS_PUBLIC_EVENT|ACTIVITI_RAW_EVENT|ACTIVITI_PUBLIC_EVENT
+    # Available category: ACS_RAW_EVENT|ACS_PUBLIC_EVENT|ACTIVITI_RAW_EVENT|ACTIVITI_PUBLIC_EVENT|CLOUD_CONNECTOR_EVENT
     eventCategory: ACS_RAW_EVENT
     startSendAtStartup: false
 


### PR DESCRIPTION
To send custom Cloud Connector events via REST API and RabbitMQ see [README](https://github.com/Alfresco/alfresco-mock-event-generator/tree/BUILDER-86#sending-custom-cloud-connector-events-via-rest-api-and-rabbitmq)

Note: If you are running the app in a docker container, you will need to set these env variables:
```
SPRING_PROFILES_ACTIVE=rabbitMQ GENERATOR_EVENTCATEGORY=CLOUD_CONNECTOR_EVENT  GENERATOR_STARTSENDATSTARTUP=false   MESSAGING_TO_RABBITMQ_HOST=<your_rabbitmq_host>  MESSAGING_TO_RABBITMQ_CAMELROUTE_DESTINATIONNAME="Example Connector"
```